### PR TITLE
Refactor/submit button disabling

### DIFF
--- a/src/Components/Question.js
+++ b/src/Components/Question.js
@@ -8,6 +8,7 @@ import { faRandom } from '@fortawesome/free-solid-svg-icons'
 
 export const Question = ({ randomQuestion, postAnswer }) => {
     const [answer, setAnswer] = useState('')
+    const [isDisabled, setDisabled] = useState(true);
 
     const submitAnswer = (event) => {
         event.preventDefault()
@@ -15,12 +16,14 @@ export const Question = ({ randomQuestion, postAnswer }) => {
                 question_id: randomQuestion.id,
             answer: answer
         }
-        console.log(newAnswer, "THIS IS THE NEW ANSWER");
+        //console.log(newAnswer, "THIS IS THE NEW ANSWER");
         postAnswer(newAnswer);
-        setAnswer('') 
+        setAnswer('')
+        setDisabled(true); 
        }
 
     const route = `/question-details/${randomQuestion.id}`;
+    //let isEnabled = answer.length;
 
     return (
         <form className='question-form answerInput'>
@@ -36,11 +39,29 @@ export const Question = ({ randomQuestion, postAnswer }) => {
                 name='answer'
                 placeholder='Write your answer here.'
                 value={answer}
-                onChange={event => setAnswer(event.target.value)}
+                onChange={event => {
+                        setAnswer(event.target.value);
+                    if (event.target.value.length){
+                        setDisabled(false);
+                    } 
+                    if (event.target.value.length == 0) {
+                        setDisabled(true);
+                    }
+                }}
             />
-            <button className='submit-btn' onClick={(event) => submitAnswer(event)}> SUBMIT </button>
+
+            <button 
+                className='submit-btn'
+                disabled={isDisabled}
+                onClick={(event) => submitAnswer(event)}>
+                    SUBMIT 
+            </button>
+
             <Link to={route}>
-            <button className='go-to-answers'> GO TO ANSWERS </button>
+                <button 
+                    className='go-to-answers'>
+                    GO TO ANSWERS
+                </button>
             </Link>
         </form>
     )

--- a/src/styles/V-components/Question.scss
+++ b/src/styles/V-components/Question.scss
@@ -50,4 +50,10 @@
   height: 30px;
   place-self: flex-end;
   margin: 10px 0px 10px 0px;
+  &:disabled {
+    &:hover {
+      cursor: not-allowed;
+      background: red;
+    }
+  }
 }


### PR DESCRIPTION
Created an intuitive error-handling that prevents users from submitting answers, unless the answer input is filled out. Additionally, I made the OnlyDevs, header a link, back to the home page. I primarily changed CSS to disable the cursor and then and make the button background red when disabled.

## Description
I used hooks inside of onChange for the input, to set the state of the submission button. Then, I check for the length of the input field to make sure if users delete text, they still can't submit an empty answer to our database. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor

## Motivation and Context
This change makes the UI more intuitive for the user and gently prods them to submit something in the answer form. 
Before this, they were able to submit an empty answer, and that could overload our server, plus they were able to answer the same question many many times.

## Concerns
-  Any bugs still present?
- Potentially we may want to disable the red background from happening immediately upon submission, because it may confuse a user, about whether or not they successfully answered the question. 
-  Next steps?
- We may want to add state to the 'go to answers' button and make that button gold. That way the user can know they successfully submitted an answer and they will be prodded to go look at that page.
