### PR TITLE
Refactor/vote btn error handling

### DIFF
--- a/src/Components/Answer.js
+++ b/src/Components/Answer.js
@@ -40,24 +40,25 @@ export const Answer = ({singleAnswer, rate}) => {
                   <button
                         className={isDisabled ? 'disabled-vote' : ''}
                         disabled={isDisabled}
+                        onClick={(e) => addCount(e)}
                   >
                     <FontAwesomeIcon
                         //className={isDisabled ? 'disabled-vote' : ''} 
-                        onClick={(e) => addCount(e)}
+                        
                         icon={faChevronCircleUp}
-                        disable={isDisabled}   
+                        //disable={isDisabled}   
                     />
                   </button>
                           <h3>{count}</h3>
                     <button
                         className={isDisabled ? 'disabled-vote' : ''}
                         disabled={isDisabled}
+                        onClick={(e) => removeCount(e)}
                     >
                         <FontAwesomeIcon 
                             //className={isDisabled ? 'disabled-vote' : ''}
-                            onClick={(e) => removeCount(e)}
                             icon={faChevronCircleDown}
-                            disable={isDisabled}           
+                            //disable={isDisabled}           
                         />
                     </button>
               </header>

--- a/src/Components/Answer.js
+++ b/src/Components/Answer.js
@@ -4,6 +4,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronCircleUp, faChevronCircleDown  } from '@fortawesome/free-solid-svg-icons';
 
 export const Answer = ({singleAnswer, rate}) => {
+
+  const [isDisabled, setIsDisabled] = useState(false);
+
   const {id, question_id, answer , rating, answer_time} = singleAnswer
   const date = parseDate(answer_time)
   const upvote = [question_id, id, 'upvote']
@@ -12,30 +15,39 @@ export const Answer = ({singleAnswer, rate}) => {
   let [count, setCount] = useState(rating)
 
 
-  const addCount = () => {
+  const addCount = (e) => {
+      e.preventDefault()
+
       setCount(count + 1)
       rate(upvote) 
-      console.log(rating)   
+      setIsDisabled(true);   
   }
 
-  const removeCount = () => {
+  const removeCount = (e) => {
+      e.preventDefault()
+
       setCount(count - 1)
       rate(downvote)
+      setIsDisabled(true);
   }
-
-
 
       return (
           <article className='answer' key={id} id={id}>
               <header className='answer-header'>
                   <p className="time">Submission date: {date}</p>
-                  <FontAwesomeIcon 
-                  onClick={() => (addCount())} icon={faChevronCircleUp}   
+                  <FontAwesomeIcon
+                    className={isDisabled ? 'disabled-vote' : ''} 
+                    onClick={(e) => addCount(e)}
+                    icon={faChevronCircleUp}
+                    disable={isDisabled}   
                   />
                           <h3>{count}</h3>
                   <FontAwesomeIcon 
-                      onClick={() => (removeCount())} icon={faChevronCircleDown}           
-                      />
+                      className={isDisabled ? 'disabled-vote' : ''}
+                      onClick={(e) => removeCount(e)}
+                      icon={faChevronCircleDown}
+                      disable={isDisabled}           
+                  />
               </header>
               <p className="answer-block">{answer}</p>
           </article>

--- a/src/Components/Answer.js
+++ b/src/Components/Answer.js
@@ -49,7 +49,7 @@ export const Answer = ({singleAnswer, rate}) => {
                         //disable={isDisabled}   
                     />
                   </button>
-                          <h3>{count}</h3>
+                          <h3>{count} Recs</h3>
                     <button
                         className={isDisabled ? 'disabled-vote' : ''}
                         disabled={isDisabled}
@@ -62,7 +62,15 @@ export const Answer = ({singleAnswer, rate}) => {
                         />
                     </button>
               </header>
-              <p className="answer-block">{answer}</p>
+              <p 
+                className='voter-msg'> 
+                    {isDisabled ? 'Recommendation recorded.': ''} 
+                    <hr/>
+              </p>
+              <p 
+              className="answer-block">
+                {answer}  
+              </p>
           </article>
       )     
 }

--- a/src/Components/Answer.js
+++ b/src/Components/Answer.js
@@ -20,7 +20,8 @@ export const Answer = ({singleAnswer, rate}) => {
 
       setCount(count + 1)
       rate(upvote) 
-      setIsDisabled(true);   
+      setIsDisabled(true); 
+      console.log(isDisabled, "INSIDE Increment COUNT");
   }
 
   const removeCount = (e) => {
@@ -29,6 +30,7 @@ export const Answer = ({singleAnswer, rate}) => {
       setCount(count - 1)
       rate(downvote)
       setIsDisabled(true);
+      console.log(isDisabled, "INSIDE REMOVE COUNT");
   }
 
       return (

--- a/src/Components/Answer.js
+++ b/src/Components/Answer.js
@@ -14,14 +14,12 @@ export const Answer = ({singleAnswer, rate}) => {
 
   let [count, setCount] = useState(rating)
 
-
   const addCount = (e) => {
       e.preventDefault()
 
       setCount(count + 1)
       rate(upvote) 
-      setIsDisabled(true); 
-      console.log(isDisabled, "INSIDE Increment COUNT");
+      setIsDisabled(true);
   }
 
   const removeCount = (e) => {
@@ -30,7 +28,6 @@ export const Answer = ({singleAnswer, rate}) => {
       setCount(count - 1)
       rate(downvote)
       setIsDisabled(true);
-      console.log(isDisabled, "INSIDE REMOVE COUNT");
   }
 
       return (
@@ -38,37 +35,32 @@ export const Answer = ({singleAnswer, rate}) => {
               <header className='answer-header'>
                   <p className="time">Submission date: {date}</p>
                   <button
-                        className={isDisabled ? 'disabled-vote' : ''}
-                        disabled={isDisabled}
-                        onClick={(e) => addCount(e)}
+                    className={isDisabled ? 'disabled-vote' : ''}
+                    disabled={isDisabled}
+                    onClick={(e) => addCount(e)}
                   >
                     <FontAwesomeIcon
-                        //className={isDisabled ? 'disabled-vote' : ''} 
-                        
                         icon={faChevronCircleUp}
-                        //disable={isDisabled}   
                     />
                   </button>
-                          <h3>{count} Recs</h3>
-                    <button
-                        className={isDisabled ? 'disabled-vote' : ''}
-                        disabled={isDisabled}
-                        onClick={(e) => removeCount(e)}
-                    >
-                        <FontAwesomeIcon 
-                            //className={isDisabled ? 'disabled-vote' : ''}
-                            icon={faChevronCircleDown}
-                            //disable={isDisabled}           
-                        />
-                    </button>
+                  <h3>{count} Recs</h3>
+                  <button
+                    className={isDisabled ? 'disabled-vote' : ''}
+                    disabled={isDisabled}
+                    onClick={(e) => removeCount(e)}
+                  >
+                    <FontAwesomeIcon 
+                        icon={faChevronCircleDown}
+                    />
+                </button>
               </header>
               <p 
                 className='voter-msg'> 
-                    {isDisabled ? 'Recommendation recorded.': ''} 
-                    <hr/>
+                {isDisabled ? 'Recommendation recorded.': ''} 
+                <hr/>
               </p>
               <p 
-              className="answer-block">
+                className="answer-block">
                 {answer}  
               </p>
           </article>

--- a/src/Components/Answer.js
+++ b/src/Components/Answer.js
@@ -37,19 +37,29 @@ export const Answer = ({singleAnswer, rate}) => {
           <article className='answer' key={id} id={id}>
               <header className='answer-header'>
                   <p className="time">Submission date: {date}</p>
-                  <FontAwesomeIcon
-                    className={isDisabled ? 'disabled-vote' : ''} 
-                    onClick={(e) => addCount(e)}
-                    icon={faChevronCircleUp}
-                    disable={isDisabled}   
-                  />
+                  <button
+                        className={isDisabled ? 'disabled-vote' : ''}
+                        disabled={isDisabled}
+                  >
+                    <FontAwesomeIcon
+                        //className={isDisabled ? 'disabled-vote' : ''} 
+                        onClick={(e) => addCount(e)}
+                        icon={faChevronCircleUp}
+                        disable={isDisabled}   
+                    />
+                  </button>
                           <h3>{count}</h3>
-                  <FontAwesomeIcon 
-                      className={isDisabled ? 'disabled-vote' : ''}
-                      onClick={(e) => removeCount(e)}
-                      icon={faChevronCircleDown}
-                      disable={isDisabled}           
-                  />
+                    <button
+                        className={isDisabled ? 'disabled-vote' : ''}
+                        disabled={isDisabled}
+                    >
+                        <FontAwesomeIcon 
+                            //className={isDisabled ? 'disabled-vote' : ''}
+                            onClick={(e) => removeCount(e)}
+                            icon={faChevronCircleDown}
+                            disable={isDisabled}           
+                        />
+                    </button>
               </header>
               <p className="answer-block">{answer}</p>
           </article>

--- a/src/styles/V-components/AnswerBoard.scss
+++ b/src/styles/V-components/AnswerBoard.scss
@@ -27,3 +27,7 @@
   }
 }
 
+.disabled-vote {
+  display: none;
+  cursor: none;
+}

--- a/src/styles/V-components/AnswerBoard.scss
+++ b/src/styles/V-components/AnswerBoard.scss
@@ -28,6 +28,10 @@
 }
 
 .disabled-vote {
-  display: none;
-  cursor: none;
+  opacity: 0.6;
+  cursor: not-allowed;
+  &:hover {
+    background-color: rgb(206, 103, 103);
+    color: white;
+  }
 }


### PR DESCRIPTION
This fix disables users from voting on an answer again and again 

## Description
I wrapped the Font Awesome Icons, in button tags, then I added state to keep track of if the buttons have been clicked once or not. After that, I added the corresponding CSS to the answerboard.scss file to make sure that the answers are displayed properly. Lastly, I displayed a message in the answer card to the user to tell them, that their input was received.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor

## Motivation and Context
This makes for a cleaner and more intuitive User Interface and doesn't allow people to spam our server or the answers as much, therefore, this makes the upvote/downvote feature of our app more meaningful. 

## Concerns
-  No more current bugs
-  Next steps?
 - Next steps would allow a specific user the ability to only upvote or downvote a specific answer once. And prevent spamming, with out making them navigate to another page first.
